### PR TITLE
Fix make_short_sentence looping endlessly if nothing was generated

### DIFF
--- a/lib/ruby_markovify/text.rb
+++ b/lib/ruby_markovify/text.rb
@@ -73,10 +73,11 @@ module RubyMarkovify
     end
 
     def make_short_sentence(char_limit, options = {})
-      loop do
+      (options[:tries] || DEFAULT_TRIES).times do
         sentence = make_sentence(nil, options)
         return sentence if sentence && sentence.length < char_limit
       end
+      nil
     end
 
     def make_sentence_with_start(beginning, options = {})


### PR DESCRIPTION
`#make_short_sentence` will loop endlessly if `#make_sentence` could not generate a sentence.  This PR fixes this problem (it's also more similar to what [markovify is doing](https://github.com/jsvine/markovify/blob/master/markovify/text.py#L134-L135))
