### PR TITLE
Port optimizations from upstream Python project

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ corpus = File.read('corpus.txt')
 # Make a text from the corpus with state size 3
 text = RubyMarkovify::Text.new(corpus, 3)
 
+# Or to disable output originality checking (faster but less fun)
+# RubyMarkovify::Text.new(corpus, 3, retain_original: false)
+
 puts text.make_sentence  # Generates a random sentence
 puts text.make_sentence_with_start('I have')  # Generates a random sentence starting with 'I have'
 puts text.make_short_sentence(40)  # Generates a random sentence at most 40 characters long

--- a/lib/ruby_markovify/text.rb
+++ b/lib/ruby_markovify/text.rb
@@ -64,10 +64,15 @@ module RubyMarkovify
       tries = options[:tries] || DEFAULT_TRIES
       mor = options[:max_overlap_ratio] || DEFAULT_MAX_OVERLAP_RATIO
       mot = options[:max_overlap_total] || DEFAULT_MAX_OVERLAP_TOTAL
+      test_output = options.fetch(:test_output, true)
 
       tries.times do
         words = @chain.walk(init_state)
-        return word_join(words) if test_sentence_output(words, mor, mot)
+        if test_output
+          return word_join(words) if test_sentence_output(words, mor, mot)
+        else
+          return word_join(words)
+        end
       end
       nil
     end

--- a/lib/ruby_markovify/text.rb
+++ b/lib/ruby_markovify/text.rb
@@ -4,10 +4,11 @@ require 'unidecode'
 
 module RubyMarkovify
   class Text
-    def initialize(input_text, state_size = nil, chain = nil)
+    def initialize(input_text, state_size = 2, chain = nil, retain_original: true)
       runs = generate_corpus(input_text)
-      @rejoined_text = sentence_join(runs.map { |e| word_join(e) })
-      state_size ||= 2
+      if retain_original
+        @rejoined_text = sentence_join(runs.map { |e| word_join(e) })
+      end
       @chain = chain || Chain.new(runs, state_size)
     end
 
@@ -68,7 +69,7 @@ module RubyMarkovify
 
       tries.times do
         words = @chain.walk(init_state)
-        if test_output
+        if test_output && defined? @rejoined_text
           return word_join(words) if test_sentence_output(words, mor, mot)
         else
           return word_join(words)


### PR DESCRIPTION
The upstream project has since been updated with multiple optimizations that make quite an impact.  In our use case, we're using a reasonably large corpus (5 public domain books) to generate text to obfuscate data in a database.  With the precomputed beginning state and setting `retain_original: false`, **our output generation is about 50x faster than on ruby_markovify's current HEAD**

I've tried to match the original code as closely as possible, as I noticed the rest of `ruby_markovify` is very faithful to the original implementation.  For reference:

Upstream implementation:
- Precomputing the beginning state:
  * https://github.com/jsvine/markovify/blob/master/markovify/chain.py#L45
  * https://github.com/jsvine/markovify/blob/master/markovify/chain.py#L74-L83
- The `:retain_original` option on the Text constructor and `:test_output` option and `:retain_original` handling in `make_sentence` (skipping the pre-parsed sentences support):
  * https://github.com/jsvine/markovify/blob/master/markovify/text.py#L29-L41
  * https://github.com/jsvine/markovify/blob/master/markovify/text.py#L171
  * https://github.com/jsvine/markovify/blob/master/markovify/text.py#L188-L192